### PR TITLE
Some SAJ Inverters provide the energy_generated in granuality of 0.1k…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Install it:
 ## Usage
 
 Create a config file for PVOutput in ```saj_collector.yaml```.
-This should contain the IP address of your SAJ Solar Invertor, and your
-PVOutput system id and API key
+This should contain the IP address of your SAJ Solar Invertor (```saj```), your
+PVOutput system id (```system_id```) and API key (```api_key```).
 
 ``` yaml
 ---
 :saj: a.b.c.d
 :system_id: 123456
 :api_key: fb6a2e3
+:day_trend_multiplication_factor: 100
 ```
 
 Run the SAJ Collector in a screen or via init of some sort
@@ -33,15 +34,18 @@ data once to PVOutput. You can add
 ``saj_collector`` to your crontab or a custom script to let it automatically push with
 a certain frequency.
 
+The SAJ Output Collector will retrieve the generation of each day of the current month and
+push the data once to PVOutput.
 Run the SAJ Output Collector in a screen or via init of some sort
 
     $ saj_output_collector
 
-This will retrieve the generation of each day of the current month and
-push the data once to PVOutput.
-You can add
-``saj_output_collector`` to your crontab or a custom script to let it automatically push with
+You can add ``saj_output_collector`` to your crontab or a custom script to let it automatically push with
 a certain frequency.
+
+Some SAJ Solar Inverters provide the generation of each day with a granularity of 0.1kWh and some with
+a granularity of 0.01kWh. In case of the last you have to change the ```day_trend_multiplication_factor```
+within your ```saj_collector.yaml``` to 10.
 
 At the moment you add any of these to your crontab you have to make sure
 that the ``saj_collector.yaml`` file can be found. For example when you put the ``saj_collector.yaml`` file

--- a/exe/saj_output_collector
+++ b/exe/saj_output_collector
@@ -30,13 +30,20 @@ options = {
 
 counter = 0
 current_day = '00'
+day_trend_multiplication = 100
+
+# Some SAJ Inverters provide they energy_generated in granularity of 0.1kWh and
+# others in 0.01kWh.
+if !sajcollector_config[:day_trend_multiplication_factor].nil?
+    day_trend_multiplication = sajcollector_config[:day_trend_multiplication_factor].to_i
+end
 
 while counter < days
   value = {
     :energy_generated => 0 }
   # Get the power output of the day,
   doc.elements.each("day_trend/d#{counter}"){
-    |e| value[:energy_generated] = (e.text.to_i * 100).to_s
+    |e| value[:energy_generated] = (e.text.to_i * day_trend_multiplication).to_s
   }
   options[:"#{m}#{current_day.next!}"] = value
 
@@ -44,7 +51,7 @@ while counter < days
 end
 
 options.each do |date, values|
-  puts "Energy generated #{date}: #{values[:energy_generated]} WH"
+  puts "Energy generated #{date}: #{values[:energy_generated]} Wh"
 end
 
 pvoutput.add_batch_output(options)


### PR DESCRIPTION
…Wh and others in

0.01kWh, we need to upload to pvoutput in Wh so make it possible for the user to
override the mutiplication factor, issue #1

    * README.md:
    * exe/saj_output_collector: